### PR TITLE
Fixed using "moviedb" module instead of "moviedb-promise" module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ npm install moviedb-promise --save
 Require the module and instantiate the class with your themoviedb.org API KEY.
 
 ```js
-const MovieDb = require('moviedb-promise');
-const moviedb = new MovieDb('your api key');
+const MovieDb = require('moviedb-promise')
+const moviedb = new MovieDb('your api key')
 ```
 
 ### `async/await` reminder
@@ -106,8 +106,8 @@ moviedb.session().then(sessionId => {
 The MovieDB constructor accepts 3 parameters:
 
 ```js
-const MovieDb = require('moviedb-promise');
-const moviedb = new MovieDb(apiKey, useDefaultLimits, baseURL);
+const MovieDb = require('moviedb-promise')
+const moviedb = new MovieDb(apiKey, useDefaultLimits, baseURL)
 ```
 
 By default, moviedb-promise limits the requests you can send to 39 requests/10 seconds (this is the limit imposed by [TheMovieDB](https://developers.themoviedb.org/3/getting-started/request-rate-limiting)). This way you won't have to deal with 429 errors.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ npm install moviedb-promise --save
 Require the module and instantiate the class with your themoviedb.org API KEY.
 
 ```js
-const MovieDb = require('moviedb')
-const moviedb = new MovieDb('your api key')
+const MovieDb = require('moviedb-promise');
+const moviedb = new MovieDb('your api key');
 ```
 
 ### `async/await` reminder
@@ -106,8 +106,8 @@ moviedb.session().then(sessionId => {
 The MovieDB constructor accepts 3 parameters:
 
 ```js
-const MovieDb = require('moviedb')
-const moviedb = new MovieDb(apiKey, useDefaultLimits, baseURL)
+const MovieDb = require('moviedb-promise');
+const moviedb = new MovieDb(apiKey, useDefaultLimits, baseURL);
 ```
 
 By default, moviedb-promise limits the requests you can send to 39 requests/10 seconds (this is the limit imposed by [TheMovieDB](https://developers.themoviedb.org/3/getting-started/request-rate-limiting)). This way you won't have to deal with 429 errors.


### PR DESCRIPTION
In the documentation as for how to use this module it mention the steps to to install `moviedb-promise` module. But when in the importing part it mention `moviedb` instead of this `moviedb-promise` module ( `const MovieDb = require('moviedb')` ). When the user use this it gives an error. So I fixed that correctly in the documentation.