### PR TITLE
Support for append_to_response

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ By default, moviedb-promise limits the requests you can send to 39 requests/10 s
 
 If you want to implement your own request rate limiter, you can set `useDefaultLimits` to `false` when creating the moviedb instance.
 
+## Support for append_to_response
+
+The movieInfo, tvInfo, tvSeasonInfo, tvEpisodeInfo and personInfo methods support an additional argument for the [TMDB api's append_to_response query parameter](https://developers.themoviedb.org/3/getting-started/append-to-response). This makes it possible to make sub requests within the same namespace in a single HTTP request. Each request will get appended to the response as a new JSON object.
+
+```js
+const res = await api.tvInfo(4629, 'season/1,season/1/credits')
+```
+
 ## Available methods
 
 The Function column lists all the available functions on the class. The Endpoint column lists possible request parameters (placehoders prefixed with `:`) needed for the call. If the endpoint doesn't have any placeholders, check out the [documentation](https://developers.themoviedb.org/3/) for the query parameters you can use.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moviedb-promise",
-  "version": "1.2.4",
+  "version": "1.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/moviedb.spec.js
+++ b/test/moviedb.spec.js
@@ -63,6 +63,12 @@ describe('moviedb', function () {
     res.should.have.property('name')
   })
 
+  it(`should get tv, season 1, season 1 episodes and credit details for Stargate SG-1`, async () => {
+    const res = await api.tvInfo(4629, 'season/1,season/1/credits')
+    res.should.be.an('object')
+    res.should.have.property('name')
+  })
+
   if (sessionId) {
     it(`should fetch the user's watchlist without including the account id in the call`, async () => {
       api.sessionId = sessionId

--- a/test/moviedb.spec.js
+++ b/test/moviedb.spec.js
@@ -67,6 +67,8 @@ describe('moviedb', function () {
     const res = await api.tvInfo(4629, 'season/1,season/1/credits')
     res.should.be.an('object')
     res.should.have.property('name')
+    res.should.have.property('season/1')
+    res.should.have.property('season/1/credits')
   })
 
   if (sessionId) {


### PR DESCRIPTION
I added an additional argument allowing for the movieInfo, tvInfo, tvSeasonInfo, tvEpisodeInfo and personInfo methods support the [TMDB api's append_to_response query parameter](https://developers.themoviedb.org/3/getting-started/append-to-response). This makes it possible to make sub requests within the same namespace in a single HTTP request. Each request will get appended to the response as a new JSON object.

Example:
```js
const res = await api.tvInfo(4629, 'season/1,season/1/credits')
```

A new test checks this feature and verifies the additional properties are included in the response.

Finally, there is another section under Advanced use explaining how to use it.