### PR TITLE
Added support for specifying a timeout parameter to methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,26 +114,6 @@ By default, moviedb-promise limits the requests you can send to 39 requests/10 s
 
 If you want to implement your own request rate limiter, you can set `useDefaultLimits` to `false` when creating the moviedb instance.
 
-## Support for append_to_response
-
-The movieInfo, tvInfo, tvSeasonInfo, tvEpisodeInfo and personInfo methods support an additional argument for the [TMDB api's append_to_response query parameter](https://developers.themoviedb.org/3/getting-started/append-to-response). This makes it possible to make sub requests within the same namespace in a single HTTP request. Each request will get appended to the response as a new JSON object.
-
-```js
-const res = await api.tvInfo(4629, 'season/1,season/1/credits')
-```
-
-## Request Timeouts
-
-To specify something other than the default timeout for a request, you may provide a third object parameter to any method in the shape of a standard [superagent timeout object](https://visionmedia.github.io/superagent/#timeouts).
-
-```js
-const res = await api.tvInfo(4629, 'season/1,season/1/credits', { response: 10000, deadline: 30000 });
-```
-or in the case where append_to_response is not desired:
-```js
-const res = await api.tvInfo(4629, null, { response: 10000, deadline: 30000 });
-```
-
 ## Available methods
 
 The Function column lists all the available functions on the class. The Endpoint column lists possible request parameters (placehoders prefixed with `:`) needed for the call. If the endpoint doesn't have any placeholders, check out the [documentation](https://developers.themoviedb.org/3/) for the query parameters you can use.
@@ -262,6 +242,36 @@ moviedb.searchMovie(parameters).then(...)
 | miscPopularTvs         | tv/popular                                                        |
 | requestToken           | authentication/token/new                                          |
 | session                | authentication/session/new                                        |
+
+## Method Options
+
+You can set additional settings for each method call by specifying the desired property on the options object parameter.
+
+## Support for append_to_response
+
+The movieInfo, tvInfo, tvSeasonInfo, tvEpisodeInfo and personInfo methods support an option to specify the [TMDB api's append_to_response query parameter](https://developers.themoviedb.org/3/getting-started/append-to-response). This makes it possible to make sub requests within the same namespace in a single HTTP request. Each request will get appended to the response as a new JSON object.
+
+```js
+const res = await api.tvInfo(4629, { append_to_response: 'season/1,season/1/credits' })
+```
+
+### Request Timeouts
+
+To specify something other than the default timeout for a method call's request, specify the timeout property of the options object. The timeout property object is the shape of a standard [superagent timeout object](https://visionmedia.github.io/superagent/#timeouts).
+
+```js
+const res = await api.tvInfo(4629, { timeout: { response: 10000, deadline: 30000 } });
+```
+or when combining multiple options append_to_response is desired:
+```js
+const res = await api.tvInfo(
+  4629,
+  {
+    append_to_response: 'season/1,season/1/credits',
+    timeout: { response: 10000, deadline: 30000 }
+  }
+);
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ The movieInfo, tvInfo, tvSeasonInfo, tvEpisodeInfo and personInfo methods suppor
 const res = await api.tvInfo(4629, 'season/1,season/1/credits')
 ```
 
+## Request Timeouts
+
+To specify something other than the default timeout for a request, you may provide a third object parameter to any method in the shape of a standard [superagent timeout object](https://visionmedia.github.io/superagent/#timeouts).
+
+```js
+const res = await api.tvInfo(4629, 'season/1,season/1/credits', { response: 10000, deadline: 30000 });
+```
+or in the case where append_to_response is not desired:
+```js
+const res = await api.tvInfo(4629, null, { response: 10000, deadline: 30000 });
+```
+
 ## Available methods
 
 The Function column lists all the available functions on the class. The Endpoint column lists possible request parameters (placehoders prefixed with `:`) needed for the call. If the endpoint doesn't have any placeholders, check out the [documentation](https://developers.themoviedb.org/3/) for the query parameters you can use.

--- a/index.js
+++ b/index.js
@@ -22,12 +22,12 @@ module.exports = class {
       const met = endpoints.methods[method]
 
       Object.keys(met).forEach(m => {
-        this[method + m] = async (params = {}, appendToResponse, timeout) => {
+        this[method + m] = async (params = {}, options = {}) => {
           if (!this.token || Date.now() > +new Date(this.token.expires_at)) {
             await this.requestToken()
           }
 
-          return this.makeRequest(met[m].method, params, met[m].resource, appendToResponse, timeout)
+          return this.makeRequest(met[m].method, params, met[m].resource, options)
         }
       })
     })
@@ -63,12 +63,15 @@ module.exports = class {
    * @param {String} type The http verb
    * @param {Object} params The parameters to pass to the api
    * @param {String} endpoint The api endpoint relative to the base url
-   * @param {String} appendToResponse optional additional argument for the TMDB api's append_to_response query parameter
-   * @param {timeout} timeout optional superagent timeout object for request
+   * @param {String|Object} options If a string, then assumed to be append_to_response. If Object, then options object
+   * @param {String} options.append_to_response additional argument for the TMDB api's append_to_response query parameter
+   * @param {timeout} options.timeout superagent timeout object for request
    * @returns {Promise}
    */
-  makeRequest (type, params, endpoint, appendToResponse, timeout) {
+  makeRequest (type, params, endpoint, options) {
     return new Promise((resolve, reject) => {
+      // Interpret options
+      const { append_to_response: appendToResponse, timeout } = (typeof options === 'string' || options instanceof String) ? { append_to_response: options } : options || ''
       // Some endpoints have an optional account_id parameter (when there's a session).
       // If it's not included, assume we want the current user's id,
       // which is setting it to '{account_id}'

--- a/index.js
+++ b/index.js
@@ -22,12 +22,12 @@ module.exports = class {
       const met = endpoints.methods[method]
 
       Object.keys(met).forEach(m => {
-        this[method + m] = async (params = {}, appendToResponse) => {
+        this[method + m] = async (params = {}, appendToResponse, timeout) => {
           if (!this.token || Date.now() > +new Date(this.token.expires_at)) {
             await this.requestToken()
           }
 
-          return this.makeRequest(met[m].method, params, met[m].resource, appendToResponse)
+          return this.makeRequest(met[m].method, params, met[m].resource, appendToResponse, timeout)
         }
       })
     })
@@ -63,9 +63,11 @@ module.exports = class {
    * @param {String} type The http verb
    * @param {Object} params The parameters to pass to the api
    * @param {String} endpoint The api endpoint relative to the base url
+   * @param {String} appendToResponse optional additional argument for the TMDB api's append_to_response query parameter
+   * @param {timeout} timeout optional superagent timeout object for request
    * @returns {Promise}
    */
-  makeRequest (type, params, endpoint, appendToResponse) {
+  makeRequest (type, params, endpoint, appendToResponse, timeout) {
     return new Promise((resolve, reject) => {
       // Some endpoints have an optional account_id parameter (when there's a session).
       // If it's not included, assume we want the current user's id,
@@ -102,6 +104,10 @@ module.exports = class {
 
       if (appendToResponse) {
         req.query({ append_to_response: appendToResponse })
+      }
+
+      if (timeout) {
+        req.timeout(timeout)
       }
 
       req[type === 'GET' ? 'query' : 'send'](params)

--- a/test/moviedb.spec.js
+++ b/test/moviedb.spec.js
@@ -71,7 +71,7 @@ describe('moviedb', function () {
 
   it(`specify a really short response (1ms) to force timeout`, async () => {
     try {
-      await api.tvInfo(4629, 'season/1,season/1/credits', { response: 1, deadline: 2 })
+      await api.tvInfo(4629, { append_to_response: 'season/1,season/1/credits', timeout: { response: 1, deadline: 2 } })
     } catch (error) {
       if (error.timeout) return
     }

--- a/test/moviedb.spec.js
+++ b/test/moviedb.spec.js
@@ -66,12 +66,27 @@ describe('moviedb', function () {
   it(`should get tv, season 1, season 1 episodes and credit details for Stargate SG-1`, async () => {
     const res = await api.tvInfo(4629, 'season/1,season/1/credits')
     res.should.be.an('object')
-    res.should.have.property('name')
+    res.should.have.property('season/1/credits')
   })
 
-  it(`specify a really short response (1ms) to force timeout`, async () => {
+  it(`specify append_to_response as option`, async () => {
+    const res = await api.tvInfo(4629, { append_to_response: 'season/1,season/1/credits' })
+    res.should.be.an('object')
+    res.should.have.property('season/1/credits')
+  })
+
+  it(`specify all options with a short response (1ms) to force timeout`, async () => {
     try {
       await api.tvInfo(4629, { append_to_response: 'season/1,season/1/credits', timeout: { response: 1, deadline: 2 } })
+    } catch (error) {
+      if (error.timeout) return
+    }
+    throw new Error('Should have thrown timeout error')
+  })
+
+  it(`specify only timeout option`, async () => {
+    try {
+      await api.tvInfo(4629, { timeout: { response: 1, deadline: 2 } })
     } catch (error) {
       if (error.timeout) return
     }

--- a/test/moviedb.spec.js
+++ b/test/moviedb.spec.js
@@ -69,6 +69,15 @@ describe('moviedb', function () {
     res.should.have.property('name')
   })
 
+  it(`specify a really short response (1ms) to force timeout`, async () => {
+    try {
+      await api.tvInfo(4629, 'season/1,season/1/credits', { response: 1, deadline: 2 })
+    } catch (error) {
+      if (error.timeout) return
+    }
+    throw new Error('Should have thrown timeout error')
+  })
+
   if (sessionId) {
     it(`should fetch the user's watchlist without including the account id in the call`, async () => {
       api.sessionId = sessionId
@@ -101,7 +110,7 @@ describe('moviedb', function () {
     const customApi = new MovieDb(apiKey, false)
 
     try {
-      let promises = new Array(requests).fill(0).map(customApi.discoverMovie)
+      let promises = new Array(requests).fill(null).map(customApi.discoverMovie)
       await Promise.all(promises)
     } catch (error) {
       return


### PR DESCRIPTION
Pull Request for Issue #10 

This would be used like:
```
const res = await api.tvInfo(4629, 'season/1,season/1/credits', { response: 10000, deadline: 30000 });
```
or in the case where append_to_response is not desired:
```
const res = await api.tvInfo(4629, null, { response: 10000, deadline: 30000 });
```
## Another approach
Instead of adding another parameter, we could send an ```options``` object as the second parameter allowing for a user to specify something like:
```
{ append_to_response: 'season/1', timeout: { response: 10000, deadline: 20000 } }
```
I decided to just send it as a third parameter for this pull request for backward compatibility, although we could just assume if the second argument is not an object, then it would be interpreted as append_to_response for backwards compatibility.

Let me know if you want it to be an 'options' argument instead of having two different arguments and I can make another pull request with that approach.
