### PR TITLE
Improved rate limiter

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,6 @@ module.exports = class {
 
       Object.keys(met).forEach(m => {
         this[method + m] = async (params = {}, options = {}) => {
-          await this.requestToken()
-
           return this.makeRequest(met[m].method, params, met[m].resource, options)
         }
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moviedb-promise",
-  "version": "1.2.6",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1125,11 +1125,6 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
-    },
-    "limits.js": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/limits.js/-/limits.js-0.1.4.tgz",
-      "integrity": "sha1-2rIe8ioXDPoO8eoBpKe+yWRrXoI="
     },
     "load-json-file": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "Valentin Mocanu <mr_vali@yahoo.ro> (http://rontavstudio.com)"
   ],
   "dependencies": {
-    "limits.js": "^0.1.4",
     "superagent": "^3.8.3"
   },
   "devDependencies": {

--- a/test/moviedb.spec.js
+++ b/test/moviedb.spec.js
@@ -123,6 +123,16 @@ describe('moviedb', function () {
     }
   })
 
+  it('should only request one token', async () => {
+    const customApi = new MovieDb(apiKey, false)
+
+    // request multiple tokens at the same time
+    let promises = new Array(10).fill(0).map(e => customApi.requestToken())
+    promises = await Promise.all(promises)
+
+    promises.map(promise => promise.should.have.property('request_token', promises[0].request_token));
+  })
+
   it('should get a rate limit error with useDefaultLimits = false', async () => {
     const requests = 50
 

--- a/test/moviedb.spec.js
+++ b/test/moviedb.spec.js
@@ -106,23 +106,6 @@ describe('moviedb', function () {
     })
   }
 
-  it('should not get a rate limit error when a lot of requests are made within 10 seconds', done => {
-    const requests = 50
-    let finishedRequests = 0
-    let i = 0
-
-    // Requests need to be fired asynchronously
-    while (i < requests) {
-      api.discoverMovie().then(res => {
-        if (++finishedRequests === requests) {
-          done()
-        }
-      }).catch(done)
-
-      i++
-    }
-  })
-
   it('should only request one token', async () => {
     const customApi = new MovieDb(apiKey, false)
 
@@ -131,6 +114,15 @@ describe('moviedb', function () {
     promises = await Promise.all(promises)
 
     promises.map(promise => promise.should.have.property('request_token', promises[0].request_token));
+  })
+
+  it('should not get a rate limit error when a lot of requests are made within 10 seconds', async () => {
+    const requests = 50
+
+    // Requests need to be fired asynchronously
+    let promises = new Array(requests).fill(0).map(api.discoverMovie)
+    promises = await Promise.all(promises)
+    promises.forEach(haveValidGenericResponse)
   })
 
   it('should get a rate limit error with useDefaultLimits = false', async () => {


### PR DESCRIPTION
Uses response headers to know how many requests can be sent. 
Auto-retries if there is a 429 Error (Too Many Requests).
Got rid of limits.js dep.

Fix #17