### PR TITLE
Fix typos in request types

### DIFF
--- a/src/request-types.ts
+++ b/src/request-types.ts
@@ -467,7 +467,7 @@ export interface DiscoverMovieRequest extends RequestParams {
   primary_release_year?: number
   'primary_release_date.gte'?: string
   'primary_release_date.lte'?: string
-  'release_date.gte?': string
+  'release_date.gte'?: string
   'release_date.lte'?: string
   with_release_type?: number
   year?: number
@@ -494,8 +494,8 @@ export interface DiscoverMovieResponse extends PaginatedResponse {
 
 export interface DiscoverTvRequest extends RequestParams {
   sort_by?: string
-  'air_date.gte?': string
-  'air_date.lte?': string
+  'air_date.gte'?: string
+  'air_date.lte'?: string
   'first_air_date.gte'?: string
   'first_air_date.lte'?: string
   first_air_date_year?: number


### PR DESCRIPTION
`?'` were the wrong way round for a few request types, which made them incorrect and also required when they shouldn't be.

I'm quite new to the world of Node.js and Typescript, so I wasn't sure if I needed to update the copies in the `dist` directory. 

I also ran `npm test` and all tests passed.