### PR TITLE
Bump axios from0.19.2 to 0.21.1 for security fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "Shaun Lim (http://github.com/ShaunLWM)"
   ],
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "lodash": "^4.17.15"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolves the following [advisory ](https://github.com/advisories/GHSA-4w2v-q235-vp99)