### PR TITLE
Add new fields to Video type

### DIFF
--- a/src/request-types.ts
+++ b/src/request-types.ts
@@ -145,6 +145,8 @@ export interface Video {
   iso_3166_1?: string
   key?: string
   name?: string
+  official?: boolean
+  published_at?: string
   site?: string
   size?: 360 | 480 | 720 | 1080
   type?: 'Trailer' | 'Teaser' | 'Clip' | 'Featurette' | 'Behind the Scenes' | 'Bloopers'


### PR DESCRIPTION
As of July 28, `official` and `published_at` have been added to the response for video

https://developers.themoviedb.org/3/movies/get-movie-videos