### PR TITLE
Added vote_average.gte property to DiscoverTvRequest interface

### DIFF
--- a/dist/request-types.d.ts
+++ b/dist/request-types.d.ts
@@ -447,6 +447,7 @@ export interface DiscoverTvRequest extends RequestParams {
     page?: number;
     timezone?: string;
     'vote_average.gte'?: number;
+    'vote_average.lte'?: number;
     'vote_count.gte'?: number;
     with_genres?: string;
     with_networks?: string;


### PR DESCRIPTION
The DiscoverTvRequest interface was missing the vote_average.lte property so I added it.