### PR TITLE
Added production_countries, spoken_languages, tagline types to ShowResponse interface

### DIFF
--- a/src/request-types.ts
+++ b/src/request-types.ts
@@ -871,8 +871,11 @@ export interface ShowResponse extends Response {
   popularity?: number
   poster_path?: string | null
   production_companies?: Array<ProductionCompany>
+  production_countries?: Array<ProductionCountry>
   seasons?: Array<SimpleSeason>
+  spoken_languages?: Array<SpokenLanguage>
   status?: string
+  tagline?: string
   type?: string
   vote_average?: number
   vote_count?: number


### PR DESCRIPTION
These types were present in MovieResponse, but not ShowResponse, which should also have them.

https://developers.themoviedb.org/3/tv-episodes/get-tv-episode-details