### PR TITLE
with_release_type should be string because of comma (AND) or pipe (OR).

### DIFF
--- a/src/moviedb.ts
+++ b/src/moviedb.ts
@@ -599,7 +599,10 @@ export class MovieDb {
     return this.makeRequest(HttpMethod.Get, 'tv/:id/season/:season_number/credits', params, axiosConfig)
   }
 
-  seasonAggregateCredits(params: types.TvAggregateCreditsRequest, axiosConfig?: AxiosRequestConfig): Promise<types.CreditsResponse> {
+  seasonAggregateCredits(
+    params: types.TvAggregateCreditsRequest,
+    axiosConfig?: AxiosRequestConfig,
+  ): Promise<types.CreditsResponse> {
     return this.makeRequest(HttpMethod.Get, 'tv/:id/season/:season_number/aggregate_credits', params, axiosConfig)
   }
 

--- a/src/request-types.ts
+++ b/src/request-types.ts
@@ -518,7 +518,7 @@ export interface DiscoverMovieRequest extends RequestParams {
   'primary_release_date.lte'?: string
   'release_date.gte'?: string
   'release_date.lte'?: string
-  with_release_type?: number
+  with_release_type?: string
   year?: number
   'vote_count.gte'?: number
   'vote_count.lte'?: number
@@ -1079,7 +1079,7 @@ export interface EpisodeExternalIdsResponse extends Response {
 }
 
 interface EpisodeImage extends BaseImage {
-  iso_639_1?: null | string;
+  iso_639_1?: null | string
 }
 
 export interface EpisodeImagesResponse extends Response {
@@ -1292,7 +1292,6 @@ interface PersonTaggedImage extends BaseImage {
   image_type?: string
   media?: MovieResult | TvResult
 }
-
 
 export interface PersonTaggedImagesResponse extends PaginatedResponse {
   id?: number

--- a/tests/moviedb.spec.js
+++ b/tests/moviedb.spec.js
@@ -10,7 +10,7 @@ const { MovieDb } = require('../dist')
 // or `MOVIEDB_SESSION_ID` in a .env
 const sessionId = process.env.MOVIEDB_SESSION_ID || process.env.npm_config_session
 
-const haveValidGenericResponse = res => {
+const haveValidGenericResponse = (res) => {
   res.should.be.an('object')
   res.should.have.property('results')
   res.results.should.be.an('array')
@@ -31,10 +31,14 @@ if (!apiKey) {
   throw new Error('Environmental variable "MOVIEDB_API_KEY" is missing.')
 }
 
-
 describe('moviedb-promise', function () {
   this.timeout(1200000)
   let api = new MovieDb(apiKey)
+
+  it('should discover movie with with a specific release type', async () => {
+    const res = await api.discoverMovie({ with_release_type: '2|3' })
+    haveValidGenericResponse(res)
+  })
 
   // basic movie search
   it('should search for Zoolander', async () => {
@@ -108,10 +112,12 @@ describe('moviedb-promise', function () {
     const promises = []
 
     for (let i = 0; i < 30; i++) {
-      promises.push(api.trending({
-        media_type: 'all',
-        time_window: 'week',
-      }))
+      promises.push(
+        api.trending({
+          media_type: 'all',
+          time_window: 'week',
+        }),
+      )
     }
 
     return Promise.all(promises)


### PR DESCRIPTION
Possible values for `with_release_type` are: [1, 2, 3, 4, 5, 6]. These values can be separated by a comma (AND) or a pipe (OR) and can be used in conjunction with the `region` parameter.

**Summary:**
- Updated the `with_release_type` parameter to accept values as a string instead of a number.

**Changes Made:**
- Modified `src/request-types.ts` on line 521 to change the type of `with_release_type` from number to string.
- Added a corresponding test in `tests/moviedb.spec.js`. This test can be removed if deemed unnecessary.