### PR TITLE
feat(Episode): Added runtime field for Episode type

### DIFF
--- a/src/request-types.ts
+++ b/src/request-types.ts
@@ -278,6 +278,7 @@ export interface Episode {
   overview?: string
   id?: number
   production_code?: string | null
+  runtime?: number
   season_number?: number
   still_path?: string | null
   vote_average?: number


### PR DESCRIPTION
This falls in line with the response from the [Get Episode Details](https://developer.themoviedb.org/reference/tv-episode-details) endpoint,
where the response has fields: `air_date`, `crew`, `episode_number`, `guest_stars`, `name`, `overview`, `id`, `production_code`, `runtime`, `season_number`, `still_path`, `vote_average`, `vote_count`
, vs. the Episode type has `runtime` missing.
